### PR TITLE
Add option to log errors to STDERR in metha-sync

### DIFF
--- a/cmd/metha-sync/main.go
+++ b/cmd/metha-sync/main.go
@@ -36,6 +36,7 @@ func main() {
 	maxEmptyReponses := flag.Int("max-empty-responses", 10, "allow a number of empty responses before failing")
 
 	logFile := flag.String("log", "", "filename to log to")
+	logStderr := flag.Bool("log-errors-to-stderr", false, "Log errors and warnings to STDERR. If -log or -q are not given, write full log to STDOUT")
 
 	flag.Parse()
 
@@ -78,6 +79,15 @@ func main() {
 			log.Fatalf("error opening log file: %s", err)
 		}
 		log.SetOutput(file)
+	}
+
+	if *logStderr {
+		if !*quiet && *logFile == "" {
+			log.Warn(`The default logger writes to STDERR. Writing errors there was explicitly requested, but -q or -log were not specified. Writing entire log to STDOUT to avoid double-writing error messages.`)
+			log.SetOutput(os.Stdout)
+		}
+
+		log.AddHook(metha.NewCopyHook(os.Stderr))
 	}
 
 	harvest, err := metha.NewHarvest(baseURL)

--- a/copyhook.go
+++ b/copyhook.go
@@ -1,0 +1,57 @@
+package metha
+
+import (
+	"io"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// CopyHook is a Logrus hook that copies messages to a writer.
+type CopyHook struct {
+	io.Writer
+	levels []log.Level
+}
+
+// NewCopyHook initializes a copy hook. By default, it copies Warn, Error, Fatal
+// and Panic level messages. Override these by passing in other logrus.Level
+// values.
+func NewCopyHook(w io.Writer, levels ...log.Level) CopyHook {
+	ch := CopyHook{
+		Writer: w,
+	}
+
+	if len(levels) > 0 {
+		ch.levels = levels
+	} else {
+		ch.levels = []log.Level{
+			log.WarnLevel,
+			log.ErrorLevel,
+			log.FatalLevel,
+			log.PanicLevel,
+		}
+	}
+
+	return ch
+}
+
+// Levels returns the levels the CopyLogger logs.
+func (hook CopyHook) Levels() []log.Level {
+	return hook.levels
+}
+
+// Fire writes a logrus message.
+func (hook CopyHook) Fire(entry *log.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		return err
+	}
+
+	for _, l := range hook.levels {
+		if l == entry.Level {
+			_, err := hook.Write([]byte(line))
+			return err
+		}
+	}
+
+	return nil
+}

--- a/copyhook_test.go
+++ b/copyhook_test.go
@@ -1,0 +1,31 @@
+package metha
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type testformatter struct{}
+
+func (f *testformatter) Format(e *log.Entry) ([]byte, error) {
+	return []byte(e.Message), nil
+}
+
+func TestCopyHook(t *testing.T) {
+	w := &bytes.Buffer{}
+
+	log.SetFormatter(new(testformatter))
+	log.SetOutput(ioutil.Discard)
+	log.AddHook(NewCopyHook(w, log.InfoLevel))
+
+	exp := "A"
+	log.Info(exp)
+	log.Warn("B")
+
+	if got := w.String(); got != exp {
+		t.Errorf("Expected '%s', got '%s'", exp, got)
+	}
+}


### PR DESCRIPTION
See the [commit message](https://github.com/gunnihinn/metha/commit/4300191e8daff91b36bf8c5c7989ce441d423efc) for a rationale for this patch.

If using `-log /dev/stdout` to avoid a spurious warning write to STDERR isn't acceptable, I can implement `-log -` as an alias for logging to STDOUT, as per [convention](https://unix.stackexchange.com/a/16364).