### PR TITLE
Marshal records with correct element name and name space

### DIFF
--- a/render.go
+++ b/render.go
@@ -72,6 +72,7 @@ func Render(opts *RenderOpts) error {
 			if opts.UseJson {
 				b, err = json.Marshal(rec)
 			} else {
+				rec.XMLName = xml.Name{Local: "record", Space: "http://www.openarchives.org/OAI/2.0/"}
 				b, err = xml.Marshal(rec)
 			}
 			if err != nil {

--- a/response.go
+++ b/response.go
@@ -3,6 +3,7 @@ package metha
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 
 	"github.com/nytlabs/mxj"
@@ -96,6 +97,7 @@ func (ab About) GoString() string { return fmt.Sprintf("%s", ab.Body) }
 
 // Record represents a single record.
 type Record struct {
+	XMLName  xml.Name
 	Header   Header   `xml:"header,omitempty" json:"header,omitempty"`
 	Metadata Metadata `xml:"metadata,omitempty" json:"metadata,omitempty"`
 	About    About    `xml:"about,omitempty" json:"about,omitempty"`


### PR DESCRIPTION
Hi,

I have introduced a fix (or workaround?) for an issue with the serialization of `record` elements in `metha-cat`, where `metha-cat` produced output like this:

```xml
<Records xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <Record>
        <header>
             <identifier>...</identifier>
             <datestamp>...</datestamp>
        </header>
        <metadata>...</metadata>
    </Record>
</Records>
```

but should actually produce output like this:

```xml
<Records xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <record xmlns="http://www.openarchives.org/OAI/2.0/">
        <header>
             <identifier>...</identifier>
             <datestamp>...</datestamp>
        </header>
        <metadata>...</metadata>
    </record>
</Records>
```

Note that in the second snippet `<record>` is lowercase and has the correct `http://www.openarchives.org/OAI/2.0/` namespace, along with its descendants. So, the issue was that OAI elements were put into the `<Records>` element's `http://www.w3.org/2001/XMLSchema-instance` namespace, and the `<Record>` vs. `<record>` "typo" mentioned above.

Hope this helps.

Cheers,
David