### PR TITLE
Encode + and space in resumptionToken - refer issue #23

### DIFF
--- a/request.go
+++ b/request.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
-	"strings"
+	"regexp"
 )
 
 var (
@@ -84,9 +84,11 @@ func (r *Request) URL() (*url.URL, error) {
 	if r.ResumptionToken != "" {
 		v.Add("resumptionToken", r.ResumptionToken)
 		var encodedValues string
-		if strings.Contains(r.ResumptionToken, " ") {
-			// http://opencontext.org/oai/request has spaces in tokens so encode in
-			// this case.
+		matched, _ := regexp.MatchString(` |\+`, r.ResumptionToken)
+		if matched {
+			// http://opencontext.org/oai/request has spaces in tokens
+			// ExLibris Rosetta has + characters in tokens
+			// Encoding in these cases
 			encodedValues = v.Encode()
 		} else {
 			// Some repos, e.g. http://dash.harvard.edu/oai/request seem to have


### PR DESCRIPTION
If `resumptionToken` has a space or a `+` in it, then encode it

Relating to issues #23

https://github.com/miku/metha/issues/23