### PR TITLE
enhance metha-sync with delay arg.

### DIFF
--- a/cmd/metha-sync/main.go
+++ b/cmd/metha-sync/main.go
@@ -20,6 +20,7 @@ var (
 	baseDir                    = flag.String("base-dir", metha.GetBaseDir(), "base dir for harvested files")
 	hourly                     = flag.Bool("hourly", false, "use hourly intervals for harvesting")
 	daily                      = flag.Bool("daily", false, "use daily intervals for harvesting")
+	delay                      = flag.Int("delay", 0, "sleep between each OAI-PMH request")
 	disableSelectiveHarvesting = flag.Bool("no-intervals", false, "harvest in one go, for funny endpoints")
 	endpointList               = flag.Bool("list", false, "list a selection of OAI endpoints (might be outdated)")
 	format                     = flag.String("format", "oai_dc", "metadata format")
@@ -118,6 +119,7 @@ func main() {
 	harvest.HourlyInterval = *hourly
 	harvest.DailyInterval = *daily
 	harvest.ExtraHeaders = extra
+	harvest.Delay = *delay
 	log.Printf("harvest: %+v", harvest)
 	if *removeCached {
 		log.Printf("removing already cached files from %s", harvest.Dir())

--- a/harvest.go
+++ b/harvest.go
@@ -67,6 +67,8 @@ type Harvest struct {
 	DailyInterval              bool
 	ExtraHeaders               http.Header
 
+	Delay int
+
 	// XXX: Lazy via sync.Once?
 	Identify *Identify
 	Started  time.Time
@@ -334,6 +336,10 @@ func (h *Harvest) runInterval(iv Interval) error {
 			filedate = iv.End.Format("2006-01-02")
 			req.From = iv.Begin.Format(h.DateLayout())
 			req.Until = iv.End.Format(h.DateLayout())
+		}
+
+		if h.Delay > 0 {
+			time.Sleep(time.Duration(h.Delay) * time.Second)
 		}
 		// Do request, return any http error, except when we ignore HTTPErrors - in that case, break out early.
 		resp, err := Do(&req)


### PR DESCRIPTION
Dear,

a suggestion to delay OAI-PMH request to a baseURL because because because some OAI-PMH interfaces respond to requests with the HTTP response code "429 - Too many request".

For some interfaces it is unclear whether they conform to Retry-After at HTTP-Header Response or/and the IETF draft ( https://www.ietf.org/id/draft-ietf-httpapi-ratelimit-headers-01.html ) for RateLimit.

To work around this issue, here is a suggestion for a pragmatic delay in metha-sync .

Best regards, 
Andreas
0000-0003-3883-4169

