### PR TITLE
metha-sync: add option to store XML files directly without compression

### DIFF
--- a/cmd/metha-sync/main.go
+++ b/cmd/metha-sync/main.go
@@ -46,6 +46,7 @@ var (
 	keepTemporaryFiles         = flag.Bool("k", false, "keep temporary files when interrupted")
 	ignoreUnexpectedEOF        = flag.Bool("ignore-unexpected-eof", false, "ignore unexpected EOF")
 	rateLimit                  = flag.String("rate-limit", "", "download rate limit (e.g., '1MB', '500KB', '2.5MB/s', '1024'). If no unit specified, bytes/sec assumed. Set to 0 or empty to disable")
+	noCompression              = flag.Bool("no-compression", false, "store harvested files as plain XML instead of .xml.gz or .xml.zst")
 )
 
 // parseRateLimit converts a human-readable rate limit string to bytes per second
@@ -200,6 +201,7 @@ func main() {
 	harvest.Config.Delay = *delay
 	harvest.Config.KeepTemporaryFiles = *keepTemporaryFiles
 	harvest.Config.IgnoreHTTPErrors = *ignoreUnexpectedEOF
+	harvest.Config.NoCompression = *noCompression
 	log.Printf("harvest: %+v", harvest)
 	if *removeCached {
 		log.Printf("removing already cached files from %s", harvest.Dir())

--- a/harvest.go
+++ b/harvest.go
@@ -80,6 +80,7 @@ type Config struct {
 	RetryBackoff               float64       // Multiplier for delay between retries (e.g., 2.0 for exponential backoff)
 	CompressionType            CompressionType
 	CompressionLevel           int // -5 to 22 for zstd
+	NoCompression              bool
 }
 
 // Harvest contains parameters for mass-download. MaxRequests and
@@ -122,9 +123,11 @@ func (h *Harvest) Dir() string {
 
 // Files returns all files for a given harvest, without the temporary files.
 func (h *Harvest) Files() []string {
+	xmlFiles := MustGlob(filepath.Join(h.Dir(), "*.xml"))
 	gzipFiles := MustGlob(filepath.Join(h.Dir(), "*.xml.gz"))
 	zstdFiles := MustGlob(filepath.Join(h.Dir(), "*.xml.zst"))
-	return append(gzipFiles, zstdFiles...)
+	files := append(xmlFiles, gzipFiles...)
+	return append(files, zstdFiles...)
 }
 
 // mkdirAll creates necessary directories.
@@ -224,6 +227,22 @@ func (h *Harvest) compressedFileExt() string {
 	}
 }
 
+// finalFileName replace func compressedFileExt
+func (h *Harvest) finalFileName(src, suffix string) string {
+	base := strings.Replace(src, suffix, "", -1)
+	if h.Config.NoCompression {
+		return base
+	}
+	switch h.Config.CompressionType {
+	case CompGzip:
+		return base + ".gz"
+	case CompZstd:
+		return base + ".zst"
+	default:
+		return base + ".zst"
+	}
+}
+
 // finalize will move all files with a given suffix into place.
 func (h *Harvest) finalize(suffix string) error {
 	var renamed []string
@@ -232,9 +251,15 @@ func (h *Harvest) finalize(suffix string) error {
 	defer h.Unlock()
 
 	for _, src := range h.temporaryFilesSuffix(suffix) {
-		dst := fmt.Sprintf("%s.%s", strings.Replace(src, suffix, "", -1), h.compressedFileExt())
+		//		dst := fmt.Sprintf("%s.%s", strings.Replace(src, suffix, "", -1), h.compressedFileExt())
+		dst := h.finalFileName(src, suffix)
 		var err error
-		if err = MoveCompressFile(src, dst, h.Config.CompressionType, h.Config.CompressionLevel); err == nil {
+		if h.Config.NoCompression {
+			err = os.Rename(src, dst)
+		} else {
+			err = MoveCompressFile(src, dst, h.Config.CompressionType, h.Config.CompressionLevel)
+		}
+		if err == nil {
 			renamed = append(renamed, dst)
 			continue
 		}


### PR DESCRIPTION
Dear,

to support requirements in the aggregation environment, `metha-sync` now provides an additional argument that allows XML files to be stored directly instead of compressing them first.

proposed argument name:
-no-compression

Best, Andreas